### PR TITLE
Update package imports and fix duration display logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,8 +4,8 @@ import {
   initModals,
   initTabs
 } from 'flowbite'
-import * as dayjs from 'dayjs'
-import * as duration from 'dayjs/plugin/duration'
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
 
 import NewsItems from './components/NewsItems.vue'
 import SettingsModal from './components/SettingsModal.vue'

--- a/src/components/FeedArticleDurationInput.vue
+++ b/src/components/FeedArticleDurationInput.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, watchEffect } from 'vue';
 import SelectDropdown from './SelectDropdown.vue';
 
 const props = defineProps({
@@ -22,8 +22,8 @@ const unitsDropdownOptions = [
   }
 ]
 
-const chosenNumber = ref(props.defaultDurationSettings.number)
-const chosenDuration = ref(props.defaultDurationSettings.duration)
+const chosenNumber = ref(0)
+const chosenDuration = ref('')
 
 const handleNumberInputChange = (e) => {
   chosenNumber.value = e.target.value
@@ -32,6 +32,11 @@ const handleNumberInputChange = (e) => {
 const handleUnitsInputChange = (value) => {
   emit('update:duration', value)
 }
+
+watchEffect(() => {
+  chosenNumber.value = props.defaultDurationSettings.number
+  chosenDuration.value = props.defaultDurationSettings.duration
+})
 </script>
 
 <template>

--- a/src/components/FeedCustomizationModal.vue
+++ b/src/components/FeedCustomizationModal.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { computed, onMounted, ref, watchEffect } from 'vue'
-import * as dayjs from 'dayjs'
-import * as duration from 'dayjs/plugin/duration'
-import * as relativeTime from 'dayjs/plugin/relativeTime'
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+import relativeTime from 'dayjs/plugin/relativeTime'
 
 import SelectDropdown from './SelectDropdown.vue'
 import CheckboxInput from './CheckboxInput.vue'

--- a/src/components/NewsItem.vue
+++ b/src/components/NewsItem.vue
@@ -1,7 +1,7 @@
 <script setup>
-import * as dayjs from 'dayjs'
-import * as relativeTime from 'dayjs/plugin/relativeTime'
-import * as updateLocale from 'dayjs/plugin/updateLocale'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import updateLocale from 'dayjs/plugin/updateLocale'
 import { computed } from 'vue'
 
 import NoImageAvailablePlaceholder from '../assets/no-image-available.png'

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onUpdated, ref, watch, watchEffect } from 'vue'
-import * as dayjs from 'dayjs'
-import * as duration from 'dayjs/plugin/duration'
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
 
 import SelectDropdown from './SelectDropdown.vue'
 import FeedArticleDurationInput from './FeedArticleDurationInput.vue'


### PR DESCRIPTION
- Update imports for dayjs to use default import syntax
- Fix how the duration variables in `FeedArticleDurationInput.vue` component are set using the props.